### PR TITLE
Remove unnecessary infrastructure

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,10 +58,4 @@
     <!-- xUnit1004 = warns about skipped tests. Make this a non-fatal build warning. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);xUnit1004</WarningsNotAsErrors>
   </PropertyGroup>
-
-  <!-- The location of the local installation of the .NET Core shared framework. -->
-  <PropertyGroup>
-    <LocalDotNetRoot>$(RepoRoot).dotnet\</LocalDotNetRoot>
-  </PropertyGroup>
-
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,27 +2,12 @@
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <!-- Workaround https://github.com/dotnet/cli/issues/10528 -->
-  <PropertyGroup>
-    <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
-  </PropertyGroup>
-
   <PropertyGroup Label="Resx settings">
     <GenerateResxSource Condition="$(GenerateResxSource) == ''">true</GenerateResxSource>
     <GenerateResxSourceEmitFormatMethods Condition="$(GenerateResxSourceEmitFormatMethods) == ''">true</GenerateResxSourceEmitFormatMethods>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Reference base shared framework at incoming dependency flow version, not bundled sdk version. -->
-    <KnownFrameworkReference Update="Microsoft.NETCore.App">
-      <!-- Always update the 'latest version', whether the repo is servicing or not. -->
-      <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">$(MicrosoftNETCoreAppRuntimeVersion)</LatestRuntimeFrameworkVersion>
-      <!-- Only update the default runtime version for preview builds. -->
-      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppRuntimeVersion)</DefaultRuntimeFrameworkVersion>
-      <!-- Only update the targeting pack version for preview builds. -->
-      <TargetingPackVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppRefPackageVersion)</TargetingPackVersion>
-    </KnownFrameworkReference>
-
     <!-- Remove unneeded reference to AspNetCore.App -->
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Compilers" Version="4.0.0-6.21526.21">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c7d6f9fab845ffd943216da465022744e7d35f22</Sha>
-    </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21473.1">
-      <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>82273cb56c83b589e8e5b63da0ac9745ffc6e105</Sha>
-    </Dependency>
-    <Dependency Name="System.CommandLine.Rendering" Version="0.3.0-alpha.21473.1">
-      <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>82273cb56c83b589e8e5b63da0ac9745ffc6e105</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.21555.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,18 +24,6 @@
 
   -->
   <PropertyGroup Label="Automated">
-    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-rtm.21518.4</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.0-rtm.21518.4</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-rtm.21518.4</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-rtm.21518.4</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-rtm.21518.4</MicrosoftNETCorePlatformsPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Label="Dependency version settings">
-    <!--
-      Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
-      All Runtime.$rid packages should have the same version.
-    -->
-    <MicrosoftNETCoreAppRuntimeVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimeVersion>
   </PropertyGroup>
   <!--
 
@@ -48,19 +36,14 @@
   -->
   <PropertyGroup Label="Manual">
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
-    <MicrosoftCodeAnalysisCommonVersion>4.0.0-4.final</MicrosoftCodeAnalysisCommonVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.0.0-4.final</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.0.1</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftExtensionsDependencyModelVersion>6.0.0</MicrosoftExtensionsDependencyModelVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>6.0.0</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
     <MoqVersion>4.10.0</MoqVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
-    <XunitAnalyzersVersion>0.10.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <XunitAssertVersion>$(XunitVersion)</XunitAssertVersion>
-    <XunitExtensibilityCoreVersion>$(XunitVersion)</XunitExtensibilityCoreVersion>
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
-    <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,17 +1,16 @@
 {
   "tools": {
-    "dotnet": "6.0.100-rc.1.21430.12",
+    "dotnet": "6.0.100",
     "runtimes": {
       "dotnet": [
-        "2.1.11",
-        "$(MicrosoftNETCoreBrowserDebugHostTransportPackageVersion)"
+        "3.1.21"
       ]
     }
   },
   "sdk": {
-    "version": "6.0.100-rc.1.21430.12"
+    "version": "6.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.21518.1"
+    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.21555.1"
   }
 }

--- a/src/Razor/startvs.cmd
+++ b/src/Razor/startvs.cmd
@@ -1,3 +1,0 @@
-@ECHO OFF
-
-%~dp0..\..\startvs.cmd %~dp0Razor.slnf

--- a/src/Razor/startvscode.sh
+++ b/src/Razor/startvscode.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-repo_root="$DIR/../.."
-"$repo_root/startvscode.sh" $DIR


### PR DESCRIPTION
- consistently use SDK content
- remove unused package versions
- move to GA 6.0 SDK and 3.1.21 runtime
  - 2.1.x runtime was unused