### PR TITLE
Get official builds working again

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,19 +3,7 @@
   <packageSources>
     <clear />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
-    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-    <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
-    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <!-- Used for the SiteExtension 3.1 bits that are included in the 5.0 build -->
-    <add key="dotnet31-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />
-    <!-- Used for the Rich Navigation indexing task -->
-    <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,9 +113,6 @@ stages:
           dependsOn:
           - Windows
           - Source_Build_Complete
-          - ${{ if ne(parameters.skipTests, 'true') }}:
-            - macOS
-            - Linux
           pool:
             vmImage: windows-latest
       jobs:


### PR DESCRIPTION
- rarely run test jobs when doing source index

Clean out NuGet.config to speed `restore` up