### PR TITLE
Bump compiler version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Versioning for assemblies/packages -->
   <PropertyGroup>
-    <MajorVersion>6</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <MajorVersion>7</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>5</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <!-- Versioning for assemblies/packages -->
   <PropertyGroup>
     <MajorVersion>6</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MinorVersion>1</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>5</PreReleaseVersionIteration>


### PR DESCRIPTION
6.0.0 already shipped so we need a slightly higher version. Bumping it up to 6.1.0 to try and emulate Roslyn's versioning scheme.