### PR TITLE
Reverting version stabilization changes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,11 +4,11 @@
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>2</PatchVersion>
-    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
Per https://github.com/dotnet/razor-compiler/pull/10/files#r760754594, we'd like to hold off on producing stable version packages right away. We'd also like to use the versioning scheme that Roslyn uses. Rolling back some parts of https://github.com/dotnet/razor-compiler/pull/10/files