### PR TITLE
Add optional range to SyntaxWalker

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxWalker.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxWalker.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
+
 /// <summary>
 /// Represents a <see cref="SyntaxVisitor"/> that descends an entire <see cref="SyntaxNode"/> graph
 /// visiting each SyntaxNode and its child SyntaxNodes and <see cref="SyntaxToken"/>s in depth-first order.

--- a/src/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxWalker.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxWalker.cs
@@ -6,8 +6,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 /// <summary>
 /// Represents a <see cref="SyntaxVisitor"/> that descends an entire <see cref="SyntaxNode"/> graph
 /// visiting each SyntaxNode and its child SyntaxNodes and <see cref="SyntaxToken"/>s in depth-first order.
-/// An optional range can be passed in which reduces the SyntaxNodes and <see cref="SyntaxToken"/>s visited
-/// to those overlapping with the given range.
+/// An optional range can be passed in which reduces the <see cref="SyntaxNode"/>s and <see cref="SyntaxToken"/>s
+/// visited to those overlapping with the given range.
 /// </summary>
 internal abstract class SyntaxWalker : SyntaxVisitor
 {

--- a/src/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxWalker.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxWalker.cs
@@ -1,19 +1,26 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
-
 /// <summary>
 /// Represents a <see cref="SyntaxVisitor"/> that descends an entire <see cref="SyntaxNode"/> graph
 /// visiting each SyntaxNode and its child SyntaxNodes and <see cref="SyntaxToken"/>s in depth-first order.
+/// An optional range can be passed in which reduces the SyntaxNodes and <see cref="SyntaxToken"/>s visited
+/// to those overlapping with the given range.
 /// </summary>
 internal abstract class SyntaxWalker : SyntaxVisitor
 {
     private int _recursionDepth;
+    private readonly TextSpan? _range;
+
+    public SyntaxWalker(TextSpan? range = null)
+    {
+        _range = range;
+    }
 
     public override void Visit(SyntaxNode node)
     {
-        if (node != null)
+        if (node != null && (_range is null || _range.Value.OverlapsWith(node.Span)))
         {
             _recursionDepth++;
             StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
@@ -30,14 +37,21 @@ internal abstract class SyntaxWalker : SyntaxVisitor
         for (var i = 0; i < children.Count; i++)
         {
             var child = children[i];
-            Visit(child);
+
+            if (_range is null || _range.Value.OverlapsWith(node.Span))
+            {
+                Visit(child);
+            }
         }
     }
 
     public override void VisitToken(SyntaxToken token)
     {
-        VisitLeadingTrivia(token);
-        VisitTrailingTrivia(token);
+        if (_range is null || _range.Value.OverlapsWith(token.Span))
+        {
+            VisitLeadingTrivia(token);
+            VisitTrailingTrivia(token);
+        }
     }
 
     public virtual void VisitLeadingTrivia(SyntaxToken token)
@@ -46,7 +60,10 @@ internal abstract class SyntaxWalker : SyntaxVisitor
         {
             foreach (var trivia in token.GetLeadingTrivia())
             {
-                VisitTrivia(trivia);
+                if (_range is null || _range.Value.OverlapsWith(token.Span))
+                {
+                    VisitTrivia(trivia);
+                }
             }
         }
     }
@@ -57,7 +74,10 @@ internal abstract class SyntaxWalker : SyntaxVisitor
         {
             foreach (var trivia in token.GetTrailingTrivia())
             {
-                VisitTrivia(trivia);
+                if (_range is null || _range.Value.OverlapsWith(token.Span))
+                {
+                    VisitTrivia(trivia);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds an optional range to `SyntaxWalker`, which reduces the `SyntaxNodes` and `SyntaxTokens` visited to those overlapping with the passed-in range.

The motivation for this change is to improve LSP semantic tokens performance (see https://github.com/dotnet/razor-tooling/issues/5775 for additional details). 