### PR TITLE
Use Roslyn to parse type names

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/src/Intermediate/ComponentAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/Intermediate/ComponentAttributeIntermediateNode.cs
@@ -158,18 +158,6 @@ public sealed class ComponentAttributeIntermediateNode : IntermediateNode
         formatter.WriteProperty(nameof(GloballyQualifiedTypeName), GloballyQualifiedTypeName);
     }
 
-    public bool TryParseEventCallbackTypeArgument(out string argument)
-    {
-        if (TryParseEventCallbackTypeArgument(out StringSegment stringSegment))
-        {
-            argument = stringSegment.Value;
-            return true;
-        }
-
-        argument = null;
-        return false;
-    }
-
     internal bool TryParseEventCallbackTypeArgument(out StringSegment argument)
     {
         // This is ugly and ad-hoc, but for various layering reasons we can't just use Roslyn APIs

--- a/src/Microsoft.AspNetCore.Razor.Language/src/TypeNameFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/TypeNameFeature.cs
@@ -11,6 +11,8 @@ internal abstract class TypeNameFeature : RazorEngineFeatureBase
 {
     public abstract IReadOnlyList<string> ParseTypeParameters(string typeName);
 
+    public abstract bool TryParseTypeName(string type, out string typeNamespace, out string typeName);
+
     public abstract TypeNameRewriter CreateGenericTypeRewriter(Dictionary<string, string> bindings);
 
     public abstract TypeNameRewriter CreateGlobalQualifiedTypeNameRewriter(ICollection<string> ignore);

--- a/src/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.Razor;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -1081,7 +1082,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
             };
         var sourceDocument = CreateComponentTestSourceDocument(@"<Counter />", "C:\\SomeFolder\\SomeProject\\Counter.cshtml");
         var tree = RazorSyntaxTree.Parse(sourceDocument);
-        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace);
+        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace, new DefaultTypeNameFeature());
 
         // Act
         visitor.Visit(tree);
@@ -1112,7 +1113,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
 ";
         var sourceDocument = CreateComponentTestSourceDocument(content, filePath);
         var tree = RazorSyntaxTree.Parse(sourceDocument);
-        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace);
+        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace, new DefaultTypeNameFeature());
 
         // Act
         visitor.Visit(tree);
@@ -1145,7 +1146,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
 ";
         var sourceDocument = CreateComponentTestSourceDocument(content, filePath);
         var tree = RazorSyntaxTree.Parse(sourceDocument);
-        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace);
+        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace, new DefaultTypeNameFeature());
 
         // Act
         visitor.Visit(tree);
@@ -1179,7 +1180,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
 ";
         var sourceDocument = CreateComponentTestSourceDocument(content, filePath);
         var tree = RazorSyntaxTree.Parse(sourceDocument);
-        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace);
+        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace, new DefaultTypeNameFeature());
 
         // Act
         visitor.Visit(tree);
@@ -1212,7 +1213,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
 ";
         var sourceDocument = CreateComponentTestSourceDocument(content, filePath);
         var tree = RazorSyntaxTree.Parse(sourceDocument);
-        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace);
+        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace, new DefaultTypeNameFeature());
 
         // Act
         visitor.Visit(tree);
@@ -1246,7 +1247,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
 ";
         var sourceDocument = CreateComponentTestSourceDocument(content, filePath);
         var tree = RazorSyntaxTree.Parse(sourceDocument);
-        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace);
+        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace, new DefaultTypeNameFeature());
 
         // Act
         visitor.Visit(tree);
@@ -1280,7 +1281,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
 ";
         var sourceDocument = CreateComponentTestSourceDocument(content, filePath);
         var tree = RazorSyntaxTree.Parse(sourceDocument);
-        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace);
+        var visitor = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(sourceDocument.FilePath, descriptors, currentNamespace, new DefaultTypeNameFeature());
 
         // Act
         visitor.Visit(tree);
@@ -1301,7 +1302,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
     public void IsTypeInNamespace_WorksAsExpected(string typeName, string @namespace, bool expected)
     {
         // Arrange & Act
-        var result = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.IsTypeInNamespace(typeName, @namespace);
+        var result = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(new DefaultTypeNameFeature()).IsTypeInNamespace(typeName, @namespace);
 
         // Assert
         Assert.Equal(expected, result);
@@ -1318,7 +1319,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
     public void IsTypeInScope_WorksAsExpected(string typeName, string currentNamespace, bool expected)
     {
         // Arrange & Act
-        var result = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.IsTypeInScope(typeName, currentNamespace);
+        var result = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(new DefaultTypeNameFeature()).IsTypeInScope(typeName, currentNamespace);
 
         // Assert
         Assert.Equal(expected, result);
@@ -1336,7 +1337,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
             assemblyName: AssemblyA);
 
         // Act
-        var result = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.IsTagHelperFromMangledClass(descriptor);
+        var result = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(new DefaultTypeNameFeature()).IsTagHelperFromMangledClass(descriptor);
 
         // Assert
         Assert.True(result);
@@ -1346,12 +1347,12 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
         new TheoryData<string, bool, string, string>
         {
                 { "", false, "", ""},
-                { ".", true, "", ""},
+                { ".", true, "", "."},
                 { "Foo", true, "", "Foo"},
                 { "SomeProject.Foo", true, "SomeProject", "Foo"},
                 { "SomeProject.Foo<Bar>", true, "SomeProject", "Foo<Bar>"},
                 { "SomeProject.Foo<Bar.Baz>", true, "SomeProject", "Foo<Bar.Baz>"},
-                { "SomeProject.Foo<Bar.Baz>>", true, "", "SomeProject.Foo<Bar.Baz>>"},
+                { "SomeProject.Foo<Bar.Baz>>", true, "SomeProject", "Foo<Bar.Baz>>"},
                 { "SomeProject..Foo<Bar>", true, "SomeProject.", "Foo<Bar>"},
         };
 
@@ -1360,13 +1361,13 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
     public void TrySplitNamespaceAndType_WorksAsExpected(string fullTypeName, bool expectedResult, string expectedNamespace, string expectedTypeName)
     {
         // Arrange & Act
-        var result = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(
+        var result = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(new DefaultTypeNameFeature()).TrySplitNamespaceAndType(
             fullTypeName, out var @namespace, out var typeName);
 
         // Assert
         Assert.Equal(expectedResult, result);
-        Assert.True(new StringSegment(expectedNamespace).Equals(@namespace, StringComparison.Ordinal));
-        Assert.True(new StringSegment(expectedTypeName).Equals(typeName, StringComparison.Ordinal));
+        Assert.Equal(new StringSegment(expectedNamespace), @namespace);
+        Assert.Equal(new StringSegment(expectedTypeName), typeName);
     }
 
     [Theory]
@@ -1376,7 +1377,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
         // Arrange & Act
         var tagHelperDescriptor = CreateTagHelperDescriptor("CoolTag", fullTypeName, AssemblyA);
 
-        var result = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(
+        var result = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(new DefaultTypeNameFeature()).TrySplitNamespaceAndType(
             tagHelperDescriptor, out var @namespace, out var typeName);
 
         // Assert
@@ -1385,7 +1386,7 @@ public class DefaultRazorTagHelperBinderPhaseTest : RazorProjectEngineTestBase
         Assert.True(new StringSegment(expectedTypeName).Equals(typeName, StringComparison.Ordinal));
 
         // Try again to make sure caching works
-        result = DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(
+        result = new DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor(new DefaultTypeNameFeature()).TrySplitNamespaceAndType(
             tagHelperDescriptor, out @namespace, out typeName);
 
         Assert.Equal(expectedResult, result);

--- a/src/Microsoft.AspNetCore.Razor.Language/test/Microsoft.AspNetCore.Razor.Language.Test.csproj
+++ b/src/Microsoft.AspNetCore.Razor.Language/test/Microsoft.AspNetCore.Razor.Language.Test.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.AspNetCore.Razor.Language.csproj" />
+    <ProjectReference Include="..\..\Microsoft.CodeAnalysis.Razor\src\Microsoft.CodeAnalysis.Razor.csproj" />
     <ProjectReference Include="..\..\test\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
     <ProjectReference Include="..\..\test\Microsoft.AspNetCore.Razor.Test.ComponentShim\Microsoft.AspNetCore.Razor.Test.ComponentShim.csproj" />
 

--- a/src/Microsoft.CodeAnalysis.Razor/src/DefaultTypeNameFeature.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/src/DefaultTypeNameFeature.cs
@@ -66,4 +66,37 @@ internal class DefaultTypeNameFeature : TypeNameFeature
         var parsed = SyntaxFactory.ParseExpression(expression);
         return parsed is LambdaExpressionSyntax;
     }
+
+    public override bool TryParseTypeName(string type, out string typeNamespace, out string typeName)
+    {
+        typeNamespace = null;
+        typeName = null;
+        try
+        {
+            var parsed = SyntaxFactory.ParseTypeName(type);
+            switch (parsed)
+            {
+                case GenericNameSyntax genericNameSyntax:
+                    typeName = genericNameSyntax.ToFullString();
+                    typeNamespace = "";
+                    return true;
+                case SimpleNameSyntax simpleNameSyntax:
+                    typeName = simpleNameSyntax.ToFullString();
+                    typeNamespace = "";
+                    return true;
+                case QualifiedNameSyntax qualifiedNameSyntax:
+                    typeName = qualifiedNameSyntax.Right.ToFullString();
+                    typeNamespace = qualifiedNameSyntax.Left.ToFullString();
+                    return true;
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+        catch (Exception)
+        {
+            typeNamespace = null;
+            typeName = null;
+            return false;
+        }
+    }
 }

--- a/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
+++ b/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor design-time infrastructure.</Description>
@@ -11,5 +11,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.AspNetCore.Razor.Language\src\Microsoft.AspNetCore.Razor.Language.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.Language.Test" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.Microbenchmarks" />    
   </ItemGroup>
 </Project>

--- a/src/Microsoft.CodeAnalysis.Razor/test/DefaultTypeNameFeatureTest.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/test/DefaultTypeNameFeatureTest.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.CodeAnalysis.Razor.Test;
+public class DefaultTypeNameFeatureTest
+{
+    [Theory]
+    [InlineData("Hello.World", true, "Hello", "World")]
+    [InlineData("IEnumerable<Something.Else>", true, "", "IEnumerable<Something.Else>")]
+    [InlineData("System.IEquatable<System.Int32>", true, "System", "IEquatable<System.Int32>")]
+    [InlineData("Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.MouseEventArgs>", true, "Microsoft.AspNetCore.Components", "EventCallback<Microsoft.AspNetCore.Components.MouseEventArgs>")]
+    public void CanParseTypeNames(string candidate, bool expectedResult, string expectedNamespace, string expectedTypeName)
+    {
+        var feature = new DefaultTypeNameFeature();
+
+        var result = feature.TryParseTypeName(candidate, out var actualNamespace, out var actualTypeName);
+        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedNamespace, actualNamespace);
+        Assert.Equal(expectedTypeName, actualTypeName);
+    }
+}

--- a/src/perf/Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
+++ b/src/perf/Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.CodeAnalysis.Razor\src\Microsoft.CodeAnalysis.Razor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="MSN.cshtml" CopyToOutputDirectory="PreserveNewest" />
     <None Include="BlazorServerTagHelpers.razor" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/perf/Microbenchmarks/RazorTagHelperParsingBenchmark.cs
+++ b/src/perf/Microbenchmarks/RazorTagHelperParsingBenchmark.cs
@@ -8,6 +8,7 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.Serialization;
+using Microsoft.CodeAnalysis.Razor;
 using Newtonsoft.Json;
 using static Microsoft.AspNetCore.Razor.Language.DefaultRazorTagHelperBinderPhase;
 
@@ -39,7 +40,7 @@ public class RazorTagHelperParsingBenchmark
             });
         BlazorServerTagHelpersDemoFile = fileSystem.GetItem(Path.Combine(blazorServerTagHelpersFilePath), FileKinds.Component);
 
-        ComponentDirectiveVisitor = new ComponentDirectiveVisitor(blazorServerTagHelpersFilePath, tagHelpers, currentNamespace: null);
+        ComponentDirectiveVisitor = new ComponentDirectiveVisitor(blazorServerTagHelpersFilePath, tagHelpers, currentNamespace: null, new DefaultTypeNameFeature());
         var codeDocument = ProjectEngine.ProcessDesignTime(BlazorServerTagHelpersDemoFile);
         SyntaxTree = codeDocument.GetSyntaxTree();
     }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/38879

The exception source seems to be coming from a place where we split a full type name into its type name and namespace. Instead of using our own "dubious" parsing logic, rely on the roslyn APIs to do the parsing.

This entailed adding a new method to `TypeNameFeature` and flowing that to the type that performs this operation.