### PR TITLE
Unify comparer implementations and improve performance

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptorComparer.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;
@@ -9,7 +7,7 @@ using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal class AllowedChildTagDescriptorComparer : IEqualityComparer<AllowedChildTagDescriptor>
+internal sealed class AllowedChildTagDescriptorComparer : IEqualityComparer<AllowedChildTagDescriptor?>
 {
     /// <summary>
     /// A default instance of the <see cref="AllowedChildTagDescriptorComparer"/>.
@@ -22,16 +20,20 @@ internal class AllowedChildTagDescriptorComparer : IEqualityComparer<AllowedChil
     }
 
     /// <inheritdoc />
-    public virtual bool Equals(
-        AllowedChildTagDescriptor descriptorX,
-        AllowedChildTagDescriptor descriptorY)
+    public bool Equals(
+        AllowedChildTagDescriptor? descriptorX,
+        AllowedChildTagDescriptor? descriptorY)
     {
         if (object.ReferenceEquals(descriptorX, descriptorY))
         {
             return true;
         }
 
-        if (descriptorX == null ^ descriptorY == null)
+        if (descriptorX is null)
+        {
+            return descriptorY is null;
+        }
+        else if (descriptorY is null)
         {
             return false;
         }
@@ -42,8 +44,13 @@ internal class AllowedChildTagDescriptorComparer : IEqualityComparer<AllowedChil
     }
 
     /// <inheritdoc />
-    public virtual int GetHashCode(AllowedChildTagDescriptor descriptor)
+    public int GetHashCode(AllowedChildTagDescriptor? descriptor)
     {
+        if (descriptor is null)
+        {
+            return 0;
+        }
+
         var hash = HashCodeCombiner.Start();
         hash.Add(descriptor.Name, StringComparer.Ordinal);
 

--- a/src/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
@@ -1,16 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal class BoundAttributeParameterDescriptorComparer : IEqualityComparer<BoundAttributeParameterDescriptor>
+internal sealed class BoundAttributeParameterDescriptorComparer : IEqualityComparer<BoundAttributeParameterDescriptor?>
 {
     /// <summary>
     /// A default instance of the <see cref="BoundAttributeParameterDescriptorComparer"/>.
@@ -21,14 +18,18 @@ internal class BoundAttributeParameterDescriptorComparer : IEqualityComparer<Bou
     {
     }
 
-    public virtual bool Equals(BoundAttributeParameterDescriptor descriptorX, BoundAttributeParameterDescriptor descriptorY)
+    public bool Equals(BoundAttributeParameterDescriptor? descriptorX, BoundAttributeParameterDescriptor? descriptorY)
     {
-        if (object.ReferenceEquals(descriptorX, descriptorY))
+        if (ReferenceEquals(descriptorX, descriptorY))
         {
             return true;
         }
 
-        if (descriptorX == null ^ descriptorY == null)
+        if (descriptorX is null)
+        {
+            return descriptorY is null;
+        }
+        else if (descriptorY is null)
         {
             return false;
         }
@@ -40,16 +41,14 @@ internal class BoundAttributeParameterDescriptorComparer : IEqualityComparer<Bou
             string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal) &&
             string.Equals(descriptorX.Documentation, descriptorY.Documentation, StringComparison.Ordinal) &&
             string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal) &&
-            Enumerable.SequenceEqual(
-                descriptorX.Metadata.OrderBy(propertyX => propertyX.Key, StringComparer.Ordinal),
-                descriptorY.Metadata.OrderBy(propertyY => propertyY.Key, StringComparer.Ordinal));
+            ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal, StringComparer.Ordinal);
     }
 
-    public virtual int GetHashCode(BoundAttributeParameterDescriptor descriptor)
+    public int GetHashCode(BoundAttributeParameterDescriptor? descriptor)
     {
         if (descriptor == null)
         {
-            throw new ArgumentNullException(nameof(descriptor));
+            return 0;
         }
 
         var hash = HashCodeCombiner.Start();

--- a/src/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal static class ComparerUtilities
+{
+    public static bool Equals<TKey, TValue>(IReadOnlyDictionary<TKey, TValue>? first, IReadOnlyDictionary<TKey, TValue>? second, IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer)
+        where TKey : notnull
+    {
+        if (first == second)
+        {
+            return true;
+        }
+
+        if (first is null)
+        {
+            return second is null;
+        }
+        else if (second is null)
+        {
+            return false;
+        }
+
+        if (first.Count != second.Count)
+        {
+            return false;
+        }
+
+        keyComparer ??= EqualityComparer<TKey>.Default;
+        valueComparer ??= EqualityComparer<TValue>.Default;
+
+        // 🐇 Avoid enumerator allocations for Dictionary<TKey, TValue>
+        if (first is Dictionary<TKey, TValue> firstDictionary
+            && second is Dictionary<TKey, TValue> secondDictionary)
+        {
+            using var firstEnumerator = firstDictionary.GetEnumerator();
+            using var secondEnumerator = secondDictionary.GetEnumerator();
+            while (firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
+            {
+                if (!keyComparer.Equals(firstEnumerator.Current.Key, secondEnumerator.Current.Key)
+                    || !valueComparer.Equals(firstEnumerator.Current.Value, secondEnumerator.Current.Value))
+                {
+                    return false;
+                }
+            }
+
+            Debug.Assert(!firstEnumerator.MoveNext() && !secondEnumerator.MoveNext(), "We already know the collections have same count.");
+            return true;
+        }
+        else
+        {
+            using var firstEnumerator = first.GetEnumerator();
+            using var secondEnumerator = second.GetEnumerator();
+            while (firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
+            {
+                if (!keyComparer.Equals(firstEnumerator.Current.Key, secondEnumerator.Current.Key)
+                    || !valueComparer.Equals(firstEnumerator.Current.Value, secondEnumerator.Current.Value))
+                {
+                    return false;
+                }
+            }
+
+            Debug.Assert(!firstEnumerator.MoveNext() && !secondEnumerator.MoveNext(), "We already know the collections have same count.");
+            return true;
+        }
+    }
+
+    public static void AddToHash<TKey, TValue>(ref HashCodeCombiner hash, IReadOnlyDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer)
+        where TKey : notnull
+    {
+        keyComparer ??= EqualityComparer<TKey>.Default;
+        valueComparer ??= EqualityComparer<TValue>.Default;
+
+        // 🐇 Avoid enumerator allocations for Dictionary<TKey, TValue>
+        if (dictionary is Dictionary<TKey, TValue> typedDictionary)
+        {
+            foreach (var kvp in typedDictionary)
+            {
+                hash.Add(kvp.Key, keyComparer);
+                hash.Add(kvp.Value, valueComparer);
+            }
+        }
+        else
+        {
+            foreach (var kvp in dictionary)
+            {
+                hash.Add(kvp.Key, keyComparer);
+                hash.Add(kvp.Value, valueComparer);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
@@ -9,6 +9,50 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 internal static class ComparerUtilities
 {
+    public static bool Equals<T>(IReadOnlyList<T>? first, IReadOnlyList<T>? second, IEqualityComparer<T>? comparer)
+    {
+        if (first == second)
+        {
+            return true;
+        }
+
+        if (first is null)
+        {
+            return second is null;
+        }
+        else if (second is null)
+        {
+            return false;
+        }
+
+        if (first.Count != second.Count)
+        {
+            return false;
+        }
+
+        comparer ??= EqualityComparer<T>.Default;
+
+        for (var i = 0; i < first.Count; i++)
+        {
+            if (!comparer.Equals(first[i], second[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static void AddToHash<T>(ref HashCodeCombiner hash, IReadOnlyList<T> list, IEqualityComparer<T>? comparer)
+    {
+        comparer ??= EqualityComparer<T>.Default;
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            hash.Add(list[i], comparer);
+        }
+    }
+
     public static bool Equals<TKey, TValue>(IReadOnlyDictionary<TKey, TValue>? first, IReadOnlyDictionary<TKey, TValue>? second, IEqualityComparer<TKey>? keyComparer, IEqualityComparer<TValue>? valueComparer)
         where TKey : notnull
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/src/RequiredAttributeDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/RequiredAttributeDescriptorComparer.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Internal;
@@ -13,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.Language;
 /// An <see cref="IEqualityComparer{TagHelperRequiredAttributeDescriptor}"/> used to check equality between
 /// two <see cref="RequiredAttributeDescriptor"/>s.
 /// </summary>
-internal class RequiredAttributeDescriptorComparer : IEqualityComparer<RequiredAttributeDescriptor>
+internal sealed class RequiredAttributeDescriptorComparer : IEqualityComparer<RequiredAttributeDescriptor?>
 {
     /// <summary>
     /// A default instance of the <see cref="RequiredAttributeDescriptorComparer"/>.
@@ -26,16 +24,20 @@ internal class RequiredAttributeDescriptorComparer : IEqualityComparer<RequiredA
     }
 
     /// <inheritdoc />
-    public virtual bool Equals(
-        RequiredAttributeDescriptor descriptorX,
-        RequiredAttributeDescriptor descriptorY)
+    public bool Equals(
+        RequiredAttributeDescriptor? descriptorX,
+        RequiredAttributeDescriptor? descriptorY)
     {
         if (object.ReferenceEquals(descriptorX, descriptorY))
         {
             return true;
         }
 
-        if (descriptorX == null ^ descriptorY == null)
+        if (descriptorX is null)
+        {
+            return descriptorY is null;
+        }
+        else if (descriptorY is null)
         {
             return false;
         }
@@ -50,11 +52,11 @@ internal class RequiredAttributeDescriptorComparer : IEqualityComparer<RequiredA
     }
 
     /// <inheritdoc />
-    public virtual int GetHashCode(RequiredAttributeDescriptor descriptor)
+    public int GetHashCode(RequiredAttributeDescriptor? descriptor)
     {
         if (descriptor == null)
         {
-            throw new ArgumentNullException(nameof(descriptor));
+            return 0;
         }
 
         var hash = HashCodeCombiner.Start();

--- a/src/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
@@ -369,6 +369,12 @@ public class DefaultTagHelperDescriptorFactoryTest
                             .TagMatchingRuleDescriptor(ruleBuilder => ruleBuilder.RequireTagName("nested-enum"))
                             .BoundAttributeDescriptor(builder =>
                                 builder
+                                    .Name("nested-enum-property")
+                                    .PropertyName(nameof(NestedEnumTagHelper.NestedEnumProperty))
+                                    .TypeName($"{typeof(NestedEnumTagHelper).FullName}.{nameof(NestedEnumTagHelper.NestedEnum)}")
+                                    .AsEnum())
+                            .BoundAttributeDescriptor(builder =>
+                                builder
                                     .Name("non-enum-property")
                                     .PropertyName(nameof(NestedEnumTagHelper.NonEnumProperty))
                                     .TypeName(typeof(int).FullName))
@@ -377,12 +383,6 @@ public class DefaultTagHelperDescriptorFactoryTest
                                     .Name("enum-property")
                                     .PropertyName(nameof(NestedEnumTagHelper.EnumProperty))
                                     .TypeName(typeof(CustomEnum).FullName)
-                                    .AsEnum())
-                            .BoundAttributeDescriptor(builder =>
-                                builder
-                                    .Name("nested-enum-property")
-                                    .PropertyName(nameof(NestedEnumTagHelper.NestedEnumProperty))
-                                    .TypeName($"{typeof(NestedEnumTagHelper).FullName}.{nameof(NestedEnumTagHelper.NestedEnum)}")
                                     .AsEnum())
                             .Build()
                     },


### PR DESCRIPTION
* Fix cases where `GetHashCode` can return different values for two instances where `Equals` would return true
* Avoid expensive `OrderBy` operations inside of `Equals`

⚠️ This pull request contains _behavior_ changes that have not been validated inside the product. While the new implementations improve consistency between `GetHashCode` and `Equals` and reduce allocation overhead for issues like AB#1464834, it simply assumes that these types are constructed in ways that naturally lead to equivalent ordering in the underlying collections.