### PR TITLE
[Blazor] Update GetGloballyQualifiedTypeName to handle cases where the value is not present

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorBuilderExtensions.cs
@@ -101,9 +101,4 @@ public static class BoundAttributeDescriptorBuilderExtensions
     {
         builder.Metadata[TagHelperMetadata.Common.GloballyQualifiedTypeName] = globallyQualifiedTypeName;
     }
-
-    public static string GetGloballyQualifiedTypeName(this BoundAttributeDescriptor descriptor)
-    {
-        return descriptor?.Metadata[TagHelperMetadata.Common.GloballyQualifiedTypeName];
-    }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorExtensions.cs
@@ -21,6 +21,17 @@ public static class BoundAttributeDescriptorExtensions
         return propertyName;
     }
 
+    public static string GetGloballyQualifiedTypeName(this BoundAttributeDescriptor attribute)
+    {
+        if (attribute == null)
+        {
+            throw new ArgumentNullException(nameof(attribute));
+        }
+
+        attribute.Metadata.TryGetValue(TagHelperMetadata.Common.GloballyQualifiedTypeName, out var propertyName);
+        return propertyName;
+    }
+
     public static bool IsDefaultKind(this BoundAttributeDescriptor attribute)
     {
         if (attribute == null)

--- a/src/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentGenericTypePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentGenericTypePass.cs
@@ -339,7 +339,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
 
             foreach (var attribute in node.Attributes)
             {
-                var globallyQualifiedTypeName = attribute.BoundAttribute.GetGloballyQualifiedTypeName();
+                var globallyQualifiedTypeName = attribute.BoundAttribute?.GetGloballyQualifiedTypeName();
 
                 if (attribute.TypeName != null)
                 {


### PR DESCRIPTION
Fixes [#40786](https://github.com/dotnet/aspnetcore/issues/40786)

Took a quick look and it fails because the value is not present on the collection. Upon inspection I detected that the code was slightly different than other helper methods, so this commit aligns that code with this one.

An interesting aspect of this issue is that the build fails only on a clean build, an incremental build does not produce any error, which is something we should look at.