### PR TITLE
Update `main` SDK to `6.0.104`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100",
+    "dotnet": "6.0.104",
     "runtimes": {
       "dotnet": [
         "3.1.21"
@@ -8,7 +8,7 @@
     }
   },
   "sdk": {
-    "version": "6.0.100"
+    "version": "6.0.104"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22171.2"


### PR DESCRIPTION
Manually updating, but created https://github.com/dotnet/razor-compiler/issues/207 to track long term automation in this area.