### PR TITLE
[release/6.0.3xx] Resolve source build prebuilts (Backport to 6.0)

### DIFF
--- a/src/test/Directory.Build.props
+++ b/src/test/Directory.Build.props
@@ -8,5 +8,6 @@
     -->
     <IsTestAssetProject>true</IsTestAssetProject>
     <IsPackable>false</IsPackable>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 </Project>

--- a/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
+++ b/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Generates Razor syntax nodes from xml. For internal use only.</Description>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFramework>
     <AssemblyName>dotnet-razorsyntaxgenerator</AssemblyName>
     <PackageId>RazorSyntaxGenerator</PackageId>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Backport of https://github.com/dotnet/razor-compiler/pull/214 to release/6.0.3xx.