### PR TITLE
Remove ConditionalWeakTable usage

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/src/Syntax/GreenNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/Syntax/GreenNode.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -18,11 +17,10 @@ internal abstract class GreenNode
 {
     private static readonly RazorDiagnostic[] EmptyDiagnostics = Array.Empty<RazorDiagnostic>();
     private static readonly SyntaxAnnotation[] EmptyAnnotations = Array.Empty<SyntaxAnnotation>();
-    private static readonly ConditionalWeakTable<GreenNode, RazorDiagnostic[]> DiagnosticsTable =
-        new ConditionalWeakTable<GreenNode, RazorDiagnostic[]>();
-    private static readonly ConditionalWeakTable<GreenNode, SyntaxAnnotation[]> AnnotationsTable =
-        new ConditionalWeakTable<GreenNode, SyntaxAnnotation[]>();
     private byte _slotCount;
+
+    private readonly RazorDiagnostic[] diagnostics = EmptyDiagnostics;
+    private readonly SyntaxAnnotation[] annotations = EmptyAnnotations;
 
     protected GreenNode(SyntaxKind kind)
     {
@@ -46,7 +44,7 @@ internal abstract class GreenNode
         if (diagnostics?.Length > 0)
         {
             Flags |= NodeFlags.ContainsDiagnostics;
-            DiagnosticsTable.Add(this, diagnostics);
+            this.diagnostics = diagnostics;
         }
 
         if (annotations?.Length > 0)
@@ -60,7 +58,7 @@ internal abstract class GreenNode
             }
 
             Flags |= NodeFlags.ContainsAnnotations;
-            AnnotationsTable.Add(this, annotations);
+            this.annotations = annotations;
         }
     }
 
@@ -229,10 +227,7 @@ internal abstract class GreenNode
     {
         if (ContainsDiagnostics)
         {
-            if (DiagnosticsTable.TryGetValue(this, out var diagnostics))
-            {
-                return diagnostics;
-            }
+            return diagnostics;
         }
 
         return EmptyDiagnostics;
@@ -246,11 +241,8 @@ internal abstract class GreenNode
     {
         if (ContainsAnnotations)
         {
-            if (AnnotationsTable.TryGetValue(this, out var annotations))
-            {
-                Debug.Assert(annotations.Length != 0, "There cannot be an empty annotation entry.");
-                return annotations;
-            }
+            Debug.Assert(annotations.Length != 0, "There cannot be an empty annotation entry.");
+            return annotations;
         }
 
         return EmptyAnnotations;


### PR DESCRIPTION
The lifetime of the diagnostics and annotations collections were being bound to the lifetime of a specific GreenNode instance by adding it to a ConditionalWeakTable. However, this ends up being no different than making these items instance fields, and the large number of dependent handles internally created by the ConditionalWeakTable has a measurable negative impact on garbage collection performance.


For comparison, I took some traces using OrchardCore before and after the changes to see what the impact would be. Since this was on my local machine, there is room for error, but there is a very clear difference between the two traces

Before:

![image](https://user-images.githubusercontent.com/60519722/171227274-ed015f93-2721-4466-bdb2-661248aca5f6.png)


After:

![image](https://user-images.githubusercontent.com/60519722/171227417-6a8d45b6-cfba-47b9-bf29-9c2cf38979f8.png)
