### PR TITLE
Temporarily produce Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal package

### DIFF
--- a/razor-compiler.sln
+++ b/razor-compiler.sln
@@ -79,6 +79,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Razo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Sdk.Razor", "src\RazorSdk\Microsoft.NET.Sdk.Razor.csproj", "{CC669C6D-C960-4C33-AB74-BA8F9AAF00AE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal", "src\tools\Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal\Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj", "{8A0EBF5D-BAD2-47E7-9577-483B19F3DC4E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -197,6 +199,10 @@ Global
 		{CC669C6D-C960-4C33-AB74-BA8F9AAF00AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC669C6D-C960-4C33-AB74-BA8F9AAF00AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC669C6D-C960-4C33-AB74-BA8F9AAF00AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A0EBF5D-BAD2-47E7-9577-483B19F3DC4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A0EBF5D-BAD2-47E7-9577-483B19F3DC4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A0EBF5D-BAD2-47E7-9577-483B19F3DC4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A0EBF5D-BAD2-47E7-9577-483B19F3DC4E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -239,6 +245,7 @@ Global
 		{8069D412-88D7-458D-9F65-A4CFC4F271E9} = {82951915-80D6-4F7B-A1DE-A5EE7D828C76}
 		{58B12344-2CA9-40F3-9E4B-0C9BAF46DFF3} = {82951915-80D6-4F7B-A1DE-A5EE7D828C76}
 		{CC669C6D-C960-4C33-AB74-BA8F9AAF00AE} = {C37BC7ED-2A86-43EB-A8AD-A26B447BFAE1}
+		{8A0EBF5D-BAD2-47E7-9577-483B19F3DC4E} = {82951915-80D6-4F7B-A1DE-A5EE7D828C76}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {43C51B30-6391-46BF-BD33-EC07D2023997}

--- a/src/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
+++ b/src/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Transport package for Razor Source Generator support.</Description>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- Need to build this project in source build -->
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+    <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Microsoft.AspNetCore.Razor.Language\src\**\*.cs" LinkBase="Language" />
+    <EmbeddedResource Include="..\Microsoft.AspNetCore.Razor.Language\src\Resources.resx"
+      ClassName="Microsoft.AspNetCore.Razor.Language.Resources" />
+    <EmbeddedResource Include="..\Microsoft.AspNetCore.Razor.Language\src\ComponentResources.resx"
+      ClassName="Microsoft.AspNetCore.Razor.Language.ComponentResources" />
+
+    <Compile Include="..\Microsoft.CodeAnalysis.Razor\src\**\*.cs" LinkBase="CodeAnalysis" />
+    <EmbeddedResource Include="..\Microsoft.CodeAnalysis.Razor\src\CodeAnalysisResources.resx"
+       ClassName="Microsoft.CodeAnalysis.Razor.CodeAnalysisResources" />
+
+    <Compile Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\**\*.cs" LinkBase="RazorExtensions" />
+    <EmbeddedResource Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\RazorExtensionsResources.resx"
+      ClassName="Microsoft.AspNetCore.Mvc.Razor.Extensions.RazorExtensionsResources" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+</Project>

--- a/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
+++ b/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Transport package for Razor Source Generator support.</Description>
@@ -11,18 +11,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.AspNetCore.Razor.Language\src\**\*.cs" LinkBase="Language" />
-    <EmbeddedResource Include="..\Microsoft.AspNetCore.Razor.Language\src\Resources.resx"
+    <Compile Include="..\..\Microsoft.AspNetCore.Razor.Language\src\**\*.cs" LinkBase="Language" />
+    <EmbeddedResource Include="..\..\Microsoft.AspNetCore.Razor.Language\src\Resources.resx"
       ClassName="Microsoft.AspNetCore.Razor.Language.Resources" />
-    <EmbeddedResource Include="..\Microsoft.AspNetCore.Razor.Language\src\ComponentResources.resx"
+    <EmbeddedResource Include="..\..\Microsoft.AspNetCore.Razor.Language\src\ComponentResources.resx"
       ClassName="Microsoft.AspNetCore.Razor.Language.ComponentResources" />
 
-    <Compile Include="..\Microsoft.CodeAnalysis.Razor\src\**\*.cs" LinkBase="CodeAnalysis" />
-    <EmbeddedResource Include="..\Microsoft.CodeAnalysis.Razor\src\CodeAnalysisResources.resx"
+    <Compile Include="..\..\Microsoft.CodeAnalysis.Razor\src\**\*.cs" LinkBase="CodeAnalysis" />
+    <EmbeddedResource Include="..\..\Microsoft.CodeAnalysis.Razor\src\CodeAnalysisResources.resx"
        ClassName="Microsoft.CodeAnalysis.Razor.CodeAnalysisResources" />
 
-    <Compile Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\**\*.cs" LinkBase="RazorExtensions" />
-    <EmbeddedResource Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\RazorExtensionsResources.resx"
+    <Compile Include="..\..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\**\*.cs" LinkBase="RazorExtensions" />
+    <EmbeddedResource Include="..\..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\RazorExtensionsResources.resx"
       ClassName="Microsoft.AspNetCore.Mvc.Razor.Extensions.RazorExtensionsResources" />
   </ItemGroup>
 


### PR DESCRIPTION
I believe this is necessary as the SDK is not consuming the new `Microsoft.NET.Sdk.Razor` transport package