### PR TITLE
Don't overwrite NoWarn in SourceGenerators.csproj

### DIFF
--- a/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+++ b/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
@@ -7,7 +7,7 @@
     <!-- This is not a package, it is part of Razor SDK. -->
     <IsPackable>false</IsPackable>
     <IsShipping>false</IsShipping>
-    <NoWarn>RS2008</NoWarn>
+    <NoWarn>$(NoWarn);RS2008</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
This file overwrites the NoWarn property when it should only add to it. This caused an issue for source-build, since we need to turn on NU1507 due to this issue: https://github.com/dotnet/razor-compiler/issues/242. I've fixed this in source-build with a patch for the moment.