### PR TITLE
Exclude the razor syntax generator from source build

### DIFF
--- a/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
+++ b/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
@@ -9,6 +9,7 @@
     <IsPackable>false</IsPackable>
     <!-- No need to track public APIs of this tool. -->
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This is a manually-run tool to update syntax nodes and doesn't need to be built by source-build. Fixes https://github.com/dotnet/razor-compiler/issues/304.
