### PR TITLE
Remove a dependency on AppHost where not needed

### DIFF
--- a/src/perf/Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
+++ b/src/perf/Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <IsPackable>false</IsPackable>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
+++ b/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
@@ -10,6 +10,7 @@
     <!-- No need to track public APIs of this tool. -->
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Some platforms, such as s390x, do not support netcoreapp3.1 and don't
have an apphost for it. Those platforms are currently primarily being
built through source-build. `<ExcludeFromSourceBuild>` doesn't seem to be
enough to stop msbuild from trying to restore the apphost and failing,
though. So disable the apphost explicitly.

Another option is to guard the `UseAppHost` on `DotNetBuildFromSource`. Is that more appropriate here?