### PR TITLE
Report compilation errors in integration tests

### DIFF
--- a/src/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
+++ b/src/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -402,14 +403,14 @@ public class RazorIntegrationTestBase
 
     private class CompilationFailedException : XunitException
     {
-        public CompilationFailedException(Compilation compilation, IEnumerable<Diagnostic> diagnostics = null)
+        public CompilationFailedException(Compilation compilation, ImmutableArray<Diagnostic>? diagnostics = null)
         {
             Compilation = compilation;
             Diagnostics = diagnostics;
         }
 
         public Compilation Compilation { get; }
-        public IEnumerable<Diagnostic> Diagnostics { get; }
+        public ImmutableArray<Diagnostic>? Diagnostics { get; }
 
         public override string Message
         {

--- a/src/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
+++ b/src/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
@@ -322,7 +322,11 @@ public class RazorIntegrationTestBase
 
         using (var peStream = new MemoryStream())
         {
-            compilation.Emit(peStream);
+            var emitResult = compilation.Emit(peStream);
+            if (!emitResult.Success)
+            {
+                throw new CompilationFailedException(compilation, emitResult.Diagnostics);
+            }
 
             return new CompileToAssemblyResult
             {
@@ -398,12 +402,14 @@ public class RazorIntegrationTestBase
 
     private class CompilationFailedException : XunitException
     {
-        public CompilationFailedException(Compilation compilation)
+        public CompilationFailedException(Compilation compilation, IEnumerable<Diagnostic> diagnostics = null)
         {
             Compilation = compilation;
+            Diagnostics = diagnostics;
         }
 
         public Compilation Compilation { get; }
+        public IEnumerable<Diagnostic> Diagnostics { get; }
 
         public override string Message
         {
@@ -412,7 +418,7 @@ public class RazorIntegrationTestBase
                 var builder = new StringBuilder();
                 builder.AppendLine("Compilation failed: ");
 
-                var diagnostics = Compilation.GetDiagnostics();
+                var diagnostics = Compilation.GetDiagnostics().Concat(Diagnostics ?? Enumerable.Empty<Diagnostic>());
                 var syntaxTreesWithErrors = new HashSet<SyntaxTree>();
                 foreach (var diagnostic in diagnostics)
                 {


### PR DESCRIPTION
Discovered while working on #347. Before applying https://github.com/dotnet/razor-compiler/pull/347/commits/94166fb9deca7bbf5cfcc8a707bf39d30fbce594, there was a missing `Microsoft.CSharp` reference. This error is reported by `compilation.Emit` but its return value was ignored. This PR makes sure these compilation errors are surfaced in integration tests.