### PR TITLE
Add route string syntax to Razor pages and Blazor

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/DefaultCodeRenderingContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/DefaultCodeRenderingContext.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -90,7 +90,7 @@ internal class DefaultCodeRenderingContext : CodeRenderingContext
 
     public override RazorDiagnosticCollection Diagnostics { get; }
 
-    public override string DocumentKind { get; }
+    public override string DocumentKind => _documentNode.DocumentKind;
 
     public override ItemCollection Items { get; }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/src/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/src/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -152,6 +152,19 @@ internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetEx
 
                 case DirectiveTokenKind.String:
 
+                    var stringSyntax = context.DocumentKind switch
+                    {
+                        "mvc.1.0.razor-page" => "Route",
+                        "component.1.0" => "ComponentRoute",
+                        _ => null
+                    };
+                    if (stringSyntax is not null)
+                    {
+                        context.CodeWriter.CurrentIndent = originalIndent;
+                        context.CodeWriter.Write("// language=").Write(stringSyntax);
+                        context.CodeWriter.CurrentIndent = 0;
+                    }
+
                     // global::System.Object __typeHelper = "{node.Content}";
                     using (context.CodeWriter.BuildLinePragma(node.Source, context))
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-compiler/issues/352

I've hacked this in. There are things todo:
1. Is this the right way to detect whether a Razor document is a Razor Page or Blazor page?
2. What is the simplest way for me to test this in Visual Studio? I'm not sure whether VS will detect and use the string syntax in the directive. Follow up work here, or in Roslyn, might be required.
3. Update dozens of failing unit tests. I'm guessing you don't update the documents manually. Is there a way to regenerate all the documents?